### PR TITLE
Fix syntax error on initialize method of <time-of-day>

### DIFF
--- a/source/slots.rst
+++ b/source/slots.rst
@@ -319,7 +319,7 @@ We define an ``initialize`` method:
 
 .. code-block:: dylan
 
-    define method initialize (time :: <time-of-day> #key)
+    define method initialize (time :: <time-of-day>, #key)
       next-method();
       if (time.total-seconds < 0)
         error("%d is invalid. total-seconds cannot be negative",


### PR DESCRIPTION
Ran into this issue implementing an initialize method based on this example, seems to be missing comma between class and key parameter
