### PR TITLE
Add missing dylan-console code block markup.

### DIFF
--- a/source/func.rst
+++ b/source/func.rst
@@ -1086,6 +1086,8 @@ Consider the following example:
 
 When we execute this code, we get the expected result:
 
+.. code-block:: dylan-console
+
     ? show-next(41);
     => The result is 42.
 


### PR DESCRIPTION
A trivial format fix, add missing dylan-console code block markup in a REPL transcript.